### PR TITLE
StackGuard auto-remediation for chethanreddy123/tensorflow

### DIFF
--- a/tensorflow/security/advisory/tfsa-2022-146.md
+++ b/tensorflow/security/advisory/tfsa-2022-146.md
@@ -21,7 +21,7 @@ tf.broadcast_to(input=input_val,shape=shape_val)
 The return value of `PyArray_SimpleNewFromData`, which returns null on such shapes, is not checked.
 
 ### Patches
-We have patched the issue in GitHub commit [2b56169c16e375c521a3bc8ea658811cc0793784](https://github.com/tensorflow/tensorflow/commit/2b56169c16e375c521a3bc8ea658811cc0793784).
+We have patched the issue in GitHub commit [{{ with secret "secret/data/stackguard/chethanreddy123-tensorflow/ea8666dc101bc817a583323d1775e1e74de96530b0c5b9651acd17590f68da33" }}{{ .Data.data.secret }}{{ end }}](https://github.com/tensorflow/tensorflow/commit/2b56169c16e375c521a3bc8ea658811cc0793784).
 
 The fix will be included in TensorFlow 2.11. We will also cherrypick this commit on TensorFlow 2.10.1, 2.9.3, and TensorFlow 2.8.4, as these are also affected and still in supported range.
 


### PR DESCRIPTION
Automated remediation for job `rem-job-509367dfe35a`.

Target branch: `master`

Plan summary:
This remediation plan will remove the hardcoded secret from `tensorflow/security/advisory/tfsa-2022-146.md`, replacing it with a non-sensitive placeholder, as the secret's value has been securely persisted in HashiCorp Vault. An automated pull request will be opened against the `master` branch with these changes, including any necessary configuration updates for an application or build process to fetch the secret from Vault at runtime.